### PR TITLE
Jack/remove exits

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+    "fmt"
+
+    "github.com/everactive/gpio"
+)
+
+func main() {
+    watcher := gpio.NewWatcher()
+    watcher.AddPin(22)
+    watcher.AddPin(27)
+    defer watcher.Close()
+
+    led1, err := gpio.NewOutput(666, true, true)
+    if err != nil {
+        panic(err)
+    }
+
+    led1.High()
+
+    led2, err := gpio.NewInput(777, true)
+    if err != nil {
+        panic(err)
+    }
+
+    val, err := led2.Read()
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Printf("value: %d\n", val)
+
+    go func() {
+        for {
+            pin, value := watcher.Watch()
+            fmt.Printf("read %d from gpio %d\n", value, pin)
+        }
+    }()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/everactive/gpio
+
+go 1.16

--- a/io.go
+++ b/io.go
@@ -29,9 +29,7 @@ func NewInput(p uint, bypassExport bool) (Pin, error) {
 	time.Sleep(10 * time.Millisecond)
 	pin.direction = inDirection
 	setDirection(pin, inDirection, 0)
-	pin = openPin(pin, false)
-
-	return pin, nil
+	return openPin(pin, false)
 }
 
 // NewOutput opens the given pin number for writing. The number provided should be the pin number known by the kernel
@@ -55,9 +53,7 @@ func NewOutput(p uint, initHigh bool, bypassExport bool) (Pin, error) {
 	}
 	pin.direction = outDirection
 	setDirection(pin, outDirection, initVal)
-	pin = openPin(pin, true)
-
-	return pin, nil
+	return openPin(pin, true)
 }
 
 // Close releases the resources related to Pin. This doen't unexport Pin, use Cleanup() instead

--- a/watcher.go
+++ b/watcher.go
@@ -4,6 +4,7 @@ import (
 	"container/heap"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"syscall"
 	"time"
@@ -93,8 +94,7 @@ func (w *Watcher) notify(fdset *syscall.FdSet) {
 					w.removeFd(fd)
 					continue
 				}
-				fmt.Printf("failed to read pinfile, %s", err)
-				os.Exit(1)
+				log.Panicf("failed to read pinfile, %s", err)
 			}
 			msg := WatcherNotification{
 				Pin:   pin.Number,
@@ -211,11 +211,10 @@ func (w *Watcher) AddPin(p uint) {
 // Edges can be configured to be either rising, falling, or both.
 // Logic level can be active high or active low.
 // The pin provided should be the pin known by the kernel.
-func (w *Watcher) AddPinWithEdgeAndLogic(p uint, edge Edge, logicLevel LogicLevel) {
+func (w *Watcher) AddPinWithEdgeAndLogic(p uint, edge Edge, logicLevel LogicLevel) error {
 	pin, err := NewInput(p, false)
 	if err != nil {
-		fmt.Printf("failed to create new input, %s", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to create new input, %s", err)
 	}
 	setLogicLevel(pin, logicLevel)
 	setEdgeTrigger(pin, edge)
@@ -223,6 +222,8 @@ func (w *Watcher) AddPinWithEdgeAndLogic(p uint, edge Edge, logicLevel LogicLeve
 		pin:    pin,
 		action: watcherAdd,
 	}
+
+	return nil
 }
 
 // RemovePin stops the watcher from watching the specified pin


### PR DESCRIPTION
Remove `os.Exit` calls in favor of error more idiomatic error returns.